### PR TITLE
Add `subscribe to extend screen`

### DIFF
--- a/danmaQ/config_dialog.py
+++ b/danmaQ/config_dialog.py
@@ -35,6 +35,17 @@ class ConfigDialog(QtGui.QDialog):
         layout.addLayout(hbox)
 
         hbox = QtGui.QHBoxLayout()
+        hbox.addWidget(QtGui.QLabel("To Extend Screen? "))
+        self._to_extend_screen = QtGui.QCheckBox(self)
+        if QtGui.QDesktopWidget().screenCount() > 1:
+            self._to_extend_screen.setChecked(True)
+        else:
+            self._to_extend_screen.setChecked(False)
+            self._to_extend_screen.setEnabled(False)
+        hbox.addWidget(self._to_extend_screen)
+        layout.addLayout(hbox)
+
+        hbox = QtGui.QHBoxLayout()
         hbox.addWidget(QtGui.QLabel("Speed Scale: "))
         self._speed = QtGui.QSlider(QtCore.Qt.Horizontal, self)
         self._speed.setTickInterval(1)
@@ -70,6 +81,7 @@ class ConfigDialog(QtGui.QDialog):
             'font_family': self._font_family.currentText(),
             'font_size': self._font_size.value(),
             'speed_scale': self._speed.value() / 10.0,
+            'to_extend_screen': self._to_extend_screen.isChecked(),
         }
 
     def save_preferences(self):
@@ -78,6 +90,7 @@ class ConfigDialog(QtGui.QDialog):
         opts['font_family'] = new_opts['font_family']
         opts['font_size'] = new_opts['font_size']
         opts['speed_scale'] = new_opts['speed_scale']
+        opts['to_extend_screen'] = new_opts['to_extend_screen']
         save_config(opts)
         self.emit_new_preferences()
 

--- a/danmaQ/danmaq_ui.py
+++ b/danmaQ/danmaq_ui.py
@@ -38,6 +38,7 @@ class Danmaku(QtGui.QLabel):
     _font_family = OPTIONS['font_family']
     _speed_scale = OPTIONS['speed_scale']
     _font_size = OPTIONS['font_size']
+    _to_extend_screen = OPTIONS['to_extend_screen']
     _interval = 30
     _style_tmpl = "font-size: {font_size}pt;" \
         + "font-family: {font_family};" \
@@ -56,6 +57,7 @@ class Danmaku(QtGui.QLabel):
         cls._font_family = opts['font_family']
         cls._font_size = opts['font_size']
         cls._speed_scale = opts['speed_scale']
+        cls._to_extend_screen = opts['to_extend_screen']
 
     @classmethod
     def escape_text(cls, text):
@@ -97,8 +99,8 @@ class Danmaku(QtGui.QLabel):
         self._width = self.frameSize().width()
         self._height = self.frameSize().height()
         self._slot = None
-        self.screenGeo = QtGui.QDesktopWidget().screenGeometry()
-
+        self.screenGeo = QtGui.QDesktopWidget().screenGeometry(
+                screen=1 if self._to_extend_screen else 0)
         with Danmaku._lock:
             if Danmaku.vertical_slots is None:
                 Danmaku._lineheight = self._height
@@ -252,6 +254,9 @@ class Danmaku(QtGui.QLabel):
                 self.y = self._lineheight * self.vslots[0] + 20
                 QtCore.QTimer.singleShot(self._lifetime, self.clean_close)
 
+        # shift to the extend screen
+        if self._to_extend_screen:
+            self.x += QtGui.QDesktopWidget().availableGeometry(screen=0).width()
         self.move(self.x, self.y)
         self.position_inited = True
 

--- a/danmaQ/settings.py
+++ b/danmaQ/settings.py
@@ -11,6 +11,7 @@ DEFAULT_OPTIONS = {
     'font_family': "WenQuanYi Micro Hei",
     'font_size': 28,
     'speed_scale': 1.0,
+    'to_extend_screen': False,
 }
 
 _xdg_cfg_dir = os.environ.get(
@@ -30,6 +31,7 @@ def load_config():
                     opts = json.loads(s)
                 else:
                     opts = json.load(f)
+            options['to_extend_screen'] = opts['to_extend_screen']
             options['font_family'] = opts['font_family']
             options['font_size'] = opts['font_size']
             options['speed_scale'] = opts['speed_scale']


### PR DESCRIPTION
Add multi-screen support in configure dialog.
If the second screen is plugged in, multi-screen checkbox will be automatically checked. Otherwise, it will be disabled.
The program ignores the third, fourth and so on (if exists) screen.
