### PR TITLE
dual-head configuration fix (for real)

### DIFF
--- a/danmaQ/app.py
+++ b/danmaQ/app.py
@@ -192,12 +192,13 @@ def init_multiscreen():
     dw = QtGui.QApplication.desktop()
     primary_screen_idx = dw.primaryScreen()
 
-    print("Primary screen: %d" % (primary_screen_idx, ))
+    # print("Primary screen: %d" % (primary_screen_idx, ))
     screen_geoms = [dw.screenGeometry(i) for i in range(dw.screenCount())]
-    print(screen_geoms)
+    # print(screen_geoms)
 
     multiscreen_manager.set_primary(primary_screen_idx)
     multiscreen_manager.populate_geometries(screen_geoms)
+
 
 def main():
     import signal

--- a/danmaQ/app.py
+++ b/danmaQ/app.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from . import __version__
 from .danmaq_ui import Danmaku
 from .tray_icon import DanmaQTrayIcon, ICON_ENABLED
-from .settings import load_config, save_config
+from .settings import load_config, save_config, multiscreen_manager
 from .config_dialog import ConfigDialog
 from .subscriber import SubscribeThread
 
@@ -188,11 +188,23 @@ class DanmakuApp(QtGui.QWidget):
         )
 
 
+def init_multiscreen():
+    dw = QtGui.QApplication.desktop()
+    primary_screen_idx = dw.primaryScreen()
+
+    print("Primary screen: %d" % (primary_screen_idx, ))
+    screen_geoms = [dw.screenGeometry(i) for i in range(dw.screenCount())]
+    print(screen_geoms)
+
+    multiscreen_manager.set_primary(primary_screen_idx)
+    multiscreen_manager.populate_geometries(screen_geoms)
+
 def main():
     import signal
     signal.signal(signal.SIGINT, signal.SIG_DFL)
     signal.signal(signal.SIGTERM, signal.SIG_DFL)
     app = QtGui.QApplication(sys.argv)
+    init_multiscreen()
     danmakuApp = DanmakuApp()
     danmakuApp.show()
     danmakuApp.place_center()

--- a/danmaQ/config_dialog.py
+++ b/danmaQ/config_dialog.py
@@ -34,18 +34,18 @@ class ConfigDialog(QtGui.QDialog):
         hbox.addWidget(self._font_size)
         layout.addLayout(hbox)
 
-        #hbox = QtGui.QHBoxLayout()
-        #hbox.addWidget(QtGui.QLabel("To Extend Screen? "))
-        #self._to_extend_screen = QtGui.QCheckBox(self)
-        #if QtGui.QDesktopWidget().screenCount() > 1:
-        #    self._to_extend_screen.setChecked(True)
-        #else:
-        #    self._to_extend_screen.setChecked(False)
-        #    self._to_extend_screen.setEnabled(False)
-        #hbox.addWidget(self._to_extend_screen)
+        hbox = QtGui.QHBoxLayout()
+        hbox.addWidget(QtGui.QLabel("To Extend Screen? "))
+        self._to_extend_screen = QtGui.QCheckBox(self)
+        if QtGui.QDesktopWidget().screenCount() > 1:
+            self._to_extend_screen.setChecked(True)
+        else:
+            self._to_extend_screen.setChecked(False)
+            self._to_extend_screen.setEnabled(False)
+        hbox.addWidget(self._to_extend_screen)
         #for i in range(hbox.count()):
         #    hbox.itemAt(i).hide()
-        #layout.addLayout(hbox)
+        layout.addLayout(hbox)
 
         hbox = QtGui.QHBoxLayout()
         hbox.addWidget(QtGui.QLabel("Speed Scale: "))
@@ -92,7 +92,7 @@ class ConfigDialog(QtGui.QDialog):
         opts['font_family'] = new_opts['font_family']
         opts['font_size'] = new_opts['font_size']
         opts['speed_scale'] = new_opts['speed_scale']
-        #opts['to_extend_screen'] = new_opts['to_extend_screen']
+        opts['to_extend_screen'] = new_opts['to_extend_screen']
         save_config(opts)
         self.emit_new_preferences()
 

--- a/danmaQ/danmaq_ui.py
+++ b/danmaQ/danmaq_ui.py
@@ -11,7 +11,7 @@ from threading import Lock
 from PyQt4 import QtCore, QtGui
 from PyQt4.QtCore import pyqtSignal
 
-from .settings import load_config
+from .settings import load_config, multiscreen_manager
 
 color_styles = {
     "white": ('rgb(255, 255, 255)', QtGui.QColor("black"), ),
@@ -99,12 +99,12 @@ class Danmaku(QtGui.QLabel):
         self._width = self.frameSize().width()
         self._height = self.frameSize().height()
         self._slot = None
-        self.screenGeo = \
-            (QtGui
-             .QDesktopWidget()
-             .screenGeometry(screen=1 if self._to_extend_screen else 0)
-             )
-        self._shift = QtGui.QDesktopWidget().availableGeometry(screen=0).width()
+
+        self.screenIdx = multiscreen_manager.get_screen_idx(self._to_extend_screen)
+        self.screenGeo = multiscreen_manager.geometry(self.screenIdx)
+        # self._shift = QtGui.QDesktopWidget().availableGeometry(screen=0).width()
+        self._offset_x = multiscreen_manager.get_offset_x(self.screenIdx, False)
+        self._origin_y = multiscreen_manager.get_origin_y(self.screenIdx)
         with Danmaku._lock:
             if Danmaku.vertical_slots is None:
                 Danmaku._lineheight = self._height
@@ -153,7 +153,9 @@ class Danmaku(QtGui.QLabel):
         nlines = self._text.count('<br/>') + 1
         # print("height: {}, lineheight: {}".format(self._height, self._lineheight))
         if self._position == 'fly':
+            # NOTE: later offseted
             self.x = self.screenGeo.width()
+
             slot = None
             with Danmaku._lock:
                 if nlines > 1:
@@ -263,8 +265,15 @@ class Danmaku(QtGui.QLabel):
                 QtCore.QTimer.singleShot(self._lifetime, self.clean_close)
 
         # shift to the extend screen
-        if self._to_extend_screen:
-            self.x += self._shift
+        #if self._to_extend_screen:
+        #    print(self._shift)
+        #    self.x += self._shift
+
+        # true multiscreen
+        self.x += self._offset_x
+        self.y += self._origin_y
+        print("initial: (%d, %d)" % (self.x, self.y, ))
+
         self.move(self.x, self.y)
         self.position_inited = True
 

--- a/danmaQ/danmaq_ui.py
+++ b/danmaQ/danmaq_ui.py
@@ -272,7 +272,7 @@ class Danmaku(QtGui.QLabel):
         # true multiscreen
         self.x += self._offset_x
         self.y += self._origin_y
-        print("initial: (%d, %d)" % (self.x, self.y, ))
+        # print("initial: (%d, %d)" % (self.x, self.y, ))
 
         self.move(self.x, self.y)
         self.position_inited = True

--- a/danmaQ/settings.py
+++ b/danmaQ/settings.py
@@ -55,4 +55,47 @@ def save_config(options):
         else:
             json.dump(options, f, indent=4)
 
+
+class MultiscreenManager(object):
+    def __init__(self):
+        self._primary_screen = 0
+        self._geoms = []
+
+    @property
+    def primary_screen(self):
+        return self._primary_screen
+
+    def geometry(self, idx):
+        return self._geoms[idx]
+
+    def populate_geometries(self, geoms):
+        self._geoms = geoms
+
+    def set_primary(self, idx):
+        self._primary_screen = idx
+
+    def get_screen_idx(self, secondary=False):
+        if len(self._geoms) < 2:
+            return 0
+
+        if len(self._geoms) >= 3:
+            raise NotImplementedError
+
+        if secondary:
+            return 1 if self._primary_screen == 0 else 0
+        else:
+            return self._primary_screen
+
+    def get_offset_x(self, idx, reversed=False):
+        geom = self.geometry(idx)
+        return geom.x() if not reversed else (geom.x() - geom.width())
+
+    def get_origin_y(self, idx):
+        geom = self.geometry(idx)
+        return geom.y()
+
+
+multiscreen_manager = MultiscreenManager()
+
+
 # vim: ts=4 sw=4 sts=4 expandtab


### PR DESCRIPTION
tested on Windows and Linux; it seems on Linux desktops the primary monitor reported is not always consistent with xrandr settings, but at least the assumption about screen layout (2nd monitor must be to the right of primary one) is removed.
