### PR TITLE
Fix build with Qt 5.14

### DIFF
--- a/src/DMCanvas.cpp
+++ b/src/DMCanvas.cpp
@@ -29,6 +29,7 @@
 #include <X11/Xregion.h>
 #include <X11/Xutil.h>
 #include <X11/extensions/shape.h>
+#undef None
 #endif
 
 #include <cstdlib>


### PR DESCRIPTION
X11 headers defined `None` which breaks new Qt headers:

```
In file included from /usr/include/X11/Xlib.h:44,
                 from /build/danmaq/src/danmaQ-0.2.3/src/DMCanvas.cpp:28:
/usr/include/qt/QtWidgets/qactiongroup.h:64:9: error: expected identifier before numeric constant
   64 |         None,
      |         ^~~~
/usr/include/qt/QtWidgets/qactiongroup.h:64:9: error: expected ‘}’ before numeric constant
In file included from /usr/include/qt/QtWidgets/qaction.h:221,
                 from /usr/include/qt/QtWidgets/qmenu.h:47,
                 from /usr/include/qt/QtWidgets/QMenu:1,
                 from /build/danmaq/src/danmaQ-0.2.3/src/DMMainWindow.hpp:26,
                 from /build/danmaq/src/danmaQ-0.2.3/src/DMCanvas.hpp:22,
                 from /build/danmaq/src/danmaQ-0.2.3/src/common.hpp:22,
                 from /build/danmaq/src/danmaQ-0.2.3/src/DMCanvas.cpp:36:
/usr/include/qt/QtWidgets/qactiongroup.h:63:32: note: to match this ‘{’
   63 |     enum class ExclusionPolicy {
      |                                ^
In file included from /usr/include/X11/Xlib.h:44,
                 from /build/danmaq/src/danmaQ-0.2.3/src/DMCanvas.cpp:28:
/usr/include/qt/QtWidgets/qactiongroup.h:64:9: error: expected unqualified-id before numeric constant
   64 |         None,
      |         ^~~~
```

Undefining `None` after importing X11 headers fixes this.